### PR TITLE
Verify the Slack token on incoming Slack requests.

### DIFF
--- a/src/oc/interaction/api/slack.clj
+++ b/src/oc/interaction/api/slack.clj
@@ -4,11 +4,12 @@
             [compojure.core :as compojure :refer (defroutes POST)]
             [taoensso.timbre :as timbre]
             [oc.lib.slack :as lib-slack]
+            [oc.interaction.config :as config]
             [oc.interaction.async.slack-mirror :as mirror]))
 
 (defn- slack-event
   "
-  Handle a message event from Slack. Ignore events that aren't threaded or that are from us.
+  Handle a message event from Slack. Ignore events that aren't threaded, or that are from us.
 
   Idea here is to do very minimal processing and get a 200 back to Slack as fast as possible as this is a 'firehose'
   of requests. So minimal logging and minimal handling of the request.
@@ -34,22 +35,34 @@
   [request]
   (let [body (:body request)
         type (get body "type")
+        token (get body "token")
         thread (get-in body ["event" "thread_ts"])]
-    (cond 
 
-      ;; This is a check of the web hook by Slack, echo back the challeng
-      (= type "url_verification") (do (timbre/info "Slack challenge") {:status 200 :body (get body "challenge")})
+    ;; Token check    
+    (if-not (= token config/slack-verification-token)
       
-      ;; If there's no thread, we aren't interested in the message
-      (nil? thread) {:status 200}
+      ;; Eghads! It might be a Slack impersonator!
+      (do 
+        (timbre/warn "Slack verification token mismatch, request provided:" token)
+        {:status 403})
 
-      :else 
-      ;; if there's a marker starting the message than this message came form us so can be ignored 
-      (let [text (get-in body ["event" "text"])]
-        (when-not (and text (re-find (re-pattern (str "^" lib-slack/marker-char)) text))
-          ;; Message from Slack, not us, with a thread and w/o our marker, might need mirrored as a comment
-          (>!! mirror/incoming-chan {:body body}))
-        {:status 200}))))
+      ;; Token check is A-OK
+      (cond 
+        ;; This is a check of the web hook by Slack, echo back the challeng
+        (= type "url_verification") (do 
+          (timbre/info "Slack challenge:" body) 
+          {:status 200 :body (get body "challenge")}) ; Slack, we're good
+        
+        ;; If there's no thread, we aren't interested in the message
+        (nil? thread) {:status 200}
+
+        :else 
+        ;; if there's a marker starting the message than this message came form us so can be ignored 
+        (let [text (get-in body ["event" "text"])]
+          (when-not (and text (re-find (re-pattern (str "^" lib-slack/marker-char)) text))
+            ;; Message from Slack, not us, with a thread and w/o our marker, might need mirrored as a comment
+            (>!! mirror/incoming-chan {:body body}))
+          {:status 200})))))
 
 ;; ----- Request Routing -----
 

--- a/src/oc/interaction/config.clj
+++ b/src/oc/interaction/config.clj
@@ -55,3 +55,7 @@
 ;; ----- JWT -----
 
 (defonce passphrase (env :open-company-auth-passphrase))
+
+;; ----- Slack -----
+
+(defonce slack-verification-token (env :open-company-slack-verification-token))


### PR DESCRIPTION
Dependent on: https://github.com/belucid/open-company-infrastructure/pull/42

This adds checking the verification token (a secret, unique to each Slack app) to verify that the HTTP request we are servicing, that is supposedly from Slack, really is from Slack. If the token doesn't match the config for the interaction service, we return a 403 and don't process the request any further.

To test:

- Ensure you have the verification token for localhost available to the interaction service
- Use ngrok to proxy service locally
- Turn on events in local Slack app
- Does the service still pass the Slack verification and handle incoming messages as you type them into Slack? Nice!
- Update the code and revert the `if-not` to an `if` on the token equality check (this simulates a token mismatch
- Try the service again, does each request from Slack fail with a 403 and logged warning and no further processing. Hot damn!
- Merge
- Whistle Ode to Joy.