### PR TITLE
Include the reactions made on a comment 

### DIFF
--- a/src/oc/interaction/api/common.clj
+++ b/src/oc/interaction/api/common.clj
@@ -108,6 +108,7 @@
   (when-let* [org (first (db-common/read-resources conn "orgs" "uuid" org-uuid))
               board (db-common/read-resource conn "boards" board-uuid)
               board-org? (= (:org-uuid board) org-uuid)
-              resource (or (db-common/read-resource conn "entries" resource-uuid)
+              resource (or (db-common/read-resource conn "interactions" resource-uuid)
+                           (db-common/read-resource conn "entries" resource-uuid)
                            (db-common/read-resource conn "stories" resource-uuid))]
     (merge resource {:org-slug (:slug org) :board-slug (:slug board)})))

--- a/src/oc/interaction/config.clj
+++ b/src/oc/interaction/config.clj
@@ -61,4 +61,4 @@
 (defonce slack-verification-token (env :open-company-slack-verification-token))
 
 ;; ----- defaults -----
-(defonce default-reactions ["👌"])
+(defonce default-reactions ["👍"])

--- a/src/oc/interaction/config.clj
+++ b/src/oc/interaction/config.clj
@@ -59,3 +59,6 @@
 ;; ----- Slack -----
 
 (defonce slack-verification-token (env :open-company-slack-verification-token))
+
+;; ----- defaults -----
+(defonce default-reactions ["👌"])

--- a/src/oc/interaction/config.clj
+++ b/src/oc/interaction/config.clj
@@ -60,5 +60,6 @@
 
 (defonce slack-verification-token (env :open-company-slack-verification-token))
 
-;; ----- defaults -----
-(defonce default-reactions ["👍"])
+;; ----- OpenCompany -----
+
+(defonce default-comment-reactions ["👍"])

--- a/src/oc/interaction/representations/interaction.clj
+++ b/src/oc/interaction/representations/interaction.clj
@@ -58,7 +58,7 @@
   [reaction interaction comment-url]
   (let [base-url (take 6 (string/split comment-url #"/"))
         comment-uuid (:uuid interaction)]
-    (str base-url "/" comment-uuid "/reactions/" reaction "/on")))
+    (str (string/join "/" base-url) "/" comment-uuid "/reactions/" reaction "/on")))
 
 (defn- comment-reaction-and-link
   "Given the reaction and comment, return a map representation of the reaction for use in the API."

--- a/src/oc/interaction/representations/interaction.clj
+++ b/src/oc/interaction/representations/interaction.clj
@@ -54,7 +54,7 @@
   (if (= (-> interaction :author :user-id) (:user-id user)) :author :none))
 
 (defn- comment-reaction-link
-  "Create a reactions url using the resource url for the comment"
+  "Create a reactions URL using the resource URL for the comment"
   [reaction interaction comment-url]
   (let [base-url (take 6 (string/split comment-url #"/"))
         comment-uuid (:uuid interaction)]
@@ -72,7 +72,7 @@
 (defn- comment-reactions
   [interaction user collection-url]
   (if (:body interaction)
-    (let [default-reactions (apply hash-map (interleave config/default-reactions (repeat [])))
+    (let [default-reactions (apply hash-map (interleave config/default-comment-reactions (repeat [])))
           grouped-reactions (merge default-reactions
                                    (group-by :reaction (:reactions interaction))) ; reactions grouped by unicode character
           counted-reactions-map (map-kv count grouped-reactions) ; how many for each character?

--- a/src/oc/interaction/representations/interaction.clj
+++ b/src/oc/interaction/representations/interaction.clj
@@ -72,7 +72,7 @@
 (defn- comment-reactions
   [interaction user collection-url]
   (if (:body interaction)
-    (let [default-reactions (apply hash-map (interleave ["Agree"] (repeat [])))
+    (let [default-reactions (apply hash-map (interleave config/default-reactions (repeat [])))
           grouped-reactions (merge default-reactions
                                    (group-by :reaction (:reactions interaction))) ; reactions grouped by unicode character
           counted-reactions-map (map-kv count grouped-reactions) ; how many for each character?

--- a/src/oc/interaction/representations/interaction.clj
+++ b/src/oc/interaction/representations/interaction.clj
@@ -79,7 +79,7 @@
           counted-reactions-map (map-kv count grouped-reactions) ; how many for each character?
           counted-reactions (map #(vec [% (get counted-reactions-map %)]) (keys counted-reactions-map))
           reaction-authors (map #(:user-id (:author %)) (:reactions interaction))
-          reacted? (not-empty (filter #(= % user) (vec reaction-authors)))]
+          reacted? (not (empty? (filter #(= % user) (vec reaction-authors))))]
       (assoc interaction :reactions
              (map #(comment-reaction-and-link % interaction reacted?) counted-reactions)))
       interaction))

--- a/src/oc/interaction/representations/interaction.clj
+++ b/src/oc/interaction/representations/interaction.clj
@@ -78,7 +78,7 @@
           counted-reactions-map (map-kv count grouped-reactions) ; how many for each character?
           counted-reactions (map #(vec [% (get counted-reactions-map %)]) (keys counted-reactions-map))
           reaction-authors (map #(:user-id (:author %)) (:reactions interaction))
-          reacted? (not (empty? (filter #(= % user) (vec reaction-authors))))]
+          reacted? (boolean (seq (filter #(= % user) (vec reaction-authors))))]
       (assoc interaction :reactions
              (map #(comment-reaction-and-link % interaction reacted? collection-url) counted-reactions)))
       interaction))

--- a/src/oc/interaction/representations/interaction.clj
+++ b/src/oc/interaction/representations/interaction.clj
@@ -79,7 +79,7 @@
           counted-reactions-map (map-kv count grouped-reactions) ; how many for each character?
           counted-reactions (map #(vec [% (get counted-reactions-map %)]) (keys counted-reactions-map))
           reaction-authors (map #(:user-id (:author %)) (:reactions interaction))
-          reacted? (not-empty? (filter #(= % user) (vec reaction-authors)))]
+          reacted? (not-empty (filter #(= % user) (vec reaction-authors)))]
       (assoc interaction :reactions
              (map #(comment-reaction-and-link % interaction reacted?) counted-reactions)))
       interaction))

--- a/src/oc/interaction/representations/interaction.clj
+++ b/src/oc/interaction/representations/interaction.clj
@@ -79,7 +79,7 @@
           counted-reactions-map (map-kv count grouped-reactions) ; how many for each character?
           counted-reactions (map #(vec [% (get counted-reactions-map %)]) (keys counted-reactions-map))
           reaction-authors (map #(:user-id (:author %)) (:reactions interaction))
-          reacted? (not (empty? (filter #(= % user) (vec reaction-authors))))]
+          reacted? (not-empty? (filter #(= % user) (vec reaction-authors)))]
       (assoc interaction :reactions
              (map #(comment-reaction-and-link % interaction reacted?) counted-reactions)))
       interaction))

--- a/src/oc/interaction/resources/interaction.clj
+++ b/src/oc/interaction/resources/interaction.clj
@@ -155,9 +155,10 @@
   (sort-by :created-at (db-common/read-resources conn table-name :resource-uuid resource-uuid)))
 
 (schema/defn ^:always-validate get-comments-by-resource
-  "Given the UUID of the resource, return the comments (sorted by :created-at)."
+  "Given the UUID of the resource, return the comments (sorted by :created-at) and the related reactions."
   [conn resource-uuid :- lib-schema/UniqueID]
-  (filter :body (get-interactions-by-resource conn resource-uuid)))
+  (let [comments (filter :body (get-interactions-by-resource conn resource-uuid))]
+    (map #(assoc % :reactions (filter :reaction (get-interactions-by-resource conn (:uuid %)))) comments)))
 
 (schema/defn ^:always-validate get-reactions-by-resource
   "


### PR DESCRIPTION
https://trello.com/c/lD7AaDcf/836-comment-reactions-agree-thumbs-up

This change includes reactions made on a comment.  Default reactions are returned if none exist.

The change also allows the API to support reactions to a comment.

To test follow the steps in https://github.com/open-company/open-company-web/pull/266