### PR TITLE
Punchlist

### DIFF
--- a/.lein-spell
+++ b/.lein-spell
@@ -1,0 +1,12 @@
+abcd
+authed
+chown
+eastwood
+kibit
+launchctl
+ngrok
+plist
+rethinkdb
+unwatch
+virtualized
+websocket

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk:
 - oraclejdk8
 lein: 2.7.1
 addons:
-  rethinkdb: '2.3.5'
+  rethinkdb: '2.3.6'
 cache:
   directories:
   - "$HOME/.m2"

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2015-2017 OpenCompany, LLC.
+Copyright © 2017-2018 OpenCompany, LLC.
 
 Mozilla Public License, version 2.0
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ ngrok http 3002
 Note the URL ngrok provides. It will look like: `http://6ae20d9b.ngrok.io` -> localhost:3002
 
 To configure the Slack to use the ngrok tunnel as the destination of message.channel events. Go to
-[Your Apps](https://api.slack.com/apps) and click the "OpenCompany (Local Development)" app.
+[Your Apps](https://api.slack.com/apps) and click the "Carrot (Local Development)" app.
 
 Click the "Event Subscriptions" navigation in the menu. Click the toggle on.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Prospective users of [Carrot](https://carrot.io/) should get started by going to
 Most of the dependencies are internal, meaning [Leiningen](https://github.com/technomancy/leiningen) will handle getting them for you. There are a few exceptions:
 
 * [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) - a Java 8 JRE is needed to run Clojure
-* [Leiningen](https://github.com/technomancy/leiningen) 2.5.1+ - Clojure's build and dependency management tool
+* [Leiningen](https://github.com/technomancy/leiningen) 2.7.1+ - Clojure's build and dependency management tool
 * [RethinkDB](http://rethinkdb.com/) v2.3.6+ - a multi-modal (document, key/value, relational) open source NoSQL database
 * [ngrok](https://ngrok.com/) - Secure web tunnel to localhost
 
@@ -301,4 +301,4 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 
 Distributed under the [Mozilla Public License v2.0](http://www.mozilla.org/MPL/2.0/).
 
-Copyright © 2015-2017 OpenCompany, LLC.
+Copyright © 2017-2018 OpenCompany, LLC.

--- a/project.clj
+++ b/project.clj
@@ -23,8 +23,9 @@
     [ring-logger-timbre "0.7.6" :exclusions [com.taoensso/encore]] ; Ring logging https://github.com/nberger/ring-logger-timbre
     [compojure "1.6.0"] ; Web routing https://github.com/weavejester/compojure
     [clj-http "3.7.0"] ; HTTP client https://github.com/dakrone/clj-http
+    [clj-soup/clojure-soup "0.1.3"] ; Clojure wrapper for jsoup HTML parser https://github.com/mfornos/clojure-soup
     
-    [open-company/lib "0.14.8"] ; Library for OC projects https://github.com/open-company/open-company-lib
+    [open-company/lib "0.14.15"] ; Library for OC projects https://github.com/open-company/open-company-lib
     ; In addition to common functions, brings in the following common dependencies used by this project:
     ; httpkit - Web server http://http-kit.org/
     ; core.async - Async programming and communication https://github.com/clojure/core.async
@@ -46,7 +47,7 @@
 
   ;; All profile plugins
   :plugins [
-    [lein-ring "0.12.2"] ; Common ring tasks https://github.com/weavejester/lein-ring
+    [lein-ring "0.12.3"] ; Common ring tasks https://github.com/weavejester/lein-ring
     [lein-environ "1.1.0"] ; Get environment settings from different sources https://github.com/weavejester/environ
   ]
 
@@ -61,7 +62,7 @@
         :open-company-auth-passphrase "this_is_a_qa_secret" ; JWT secret
       }
       :dependencies [
-        [midje "1.9.0"] ; Example-based testing https://github.com/marick/Midje
+        [midje "1.9.2-alpha2"] ; Example-based testing https://github.com/marick/Midje
         [ring-mock "0.1.5"] ; Test Ring requests https://github.com/weavejester/ring-mock
       ]
       :plugins [
@@ -88,7 +89,7 @@
         [lein-bikeshed "0.5.0"] ; Check for code smells https://github.com/dakrone/lein-bikeshed
         [lein-checkall "0.1.1"] ; Runs bikeshed, kibit and eastwood https://github.com/itang/lein-checkall
         [lein-pprint "1.2.0"] ; pretty-print the lein project map https://github.com/technomancy/leiningen/tree/master/lein-pprint
-        [lein-ancient "0.6.14"] ; Check for outdated dependencies https://github.com/xsc/lein-ancient
+        [lein-ancient "0.6.15"] ; Check for outdated dependencies https://github.com/xsc/lein-ancient
         [lein-spell "0.1.0"] ; Catch spelling mistakes in docs and docstrings https://github.com/cldwalker/lein-spell
         [lein-deps-tree "0.1.2"] ; Print a tree of project dependencies https://github.com/the-kenny/lein-deps-tree
         [venantius/yagni "0.1.4"] ; Dead code finder https://github.com/venantius/yagni

--- a/src/oc/interaction/api/websockets.clj
+++ b/src/oc/interaction/api/websockets.clj
@@ -5,9 +5,9 @@
             [taoensso.timbre :as timbre]
             [compojure.core :as compojure :refer (defroutes GET POST)]
             [taoensso.sente.server-adapters.http-kit :refer (get-sch-adapter)]
+            [oc.lib.async.watcher :as watcher]
             [oc.lib.jwt :as jwt]
-            [oc.interaction.config :as c]
-            [oc.interaction.async.watcher :as watcher]))
+            [oc.interaction.config :as c]))
 
 ;; ----- core.async -----
 

--- a/src/oc/interaction/async/slack_mirror.clj
+++ b/src/oc/interaction/async/slack_mirror.clj
@@ -25,8 +25,7 @@
 
 ;; ----- Slack message copy -----
 
-(def echo-intro "commenting on:")
-(def proxy-intro "There's a comment on:")
+(def echo-intro "commented on:")
 
 ;; ----- Slack defaults -----
 
@@ -225,13 +224,14 @@
                   channel-id (:channel-id slack-channel)
                   thread (:thread slack-channel)
                   author (-> message :author :name)
-                  text (str author " said: " (.text (soup/parse (:body interaction))))]
+                  text (.text (soup/parse (:body interaction)))]
               (if thread
                 (timbre/info "Proxying comment to Slack:" uuid "on thread:" thread)
                 (timbre/info "Proxying comment to Slack:" uuid "as a new thread"))
               (let [result (if thread
-                              (slack/proxy-message token channel-id thread text)
-                              (slack/proxy-message token channel-id (initial-message proxy-intro text resource interaction)))]
+                              (slack/proxy-message token channel-id thread (str "*" author "* said:\n> " text))
+                              (slack/proxy-message token channel-id
+                                (initial-message (str author " " echo-intro) text resource interaction)))]
                 (if (:ok result)
                   (do
                     (timbre/info "Proxied to Slack:" uuid)

--- a/src/oc/interaction/async/slack_mirror.clj
+++ b/src/oc/interaction/async/slack_mirror.clj
@@ -15,6 +15,7 @@
             [clojure.core.cache :as cache]
             [if-let.core :refer (if-let*)]
             [taoensso.timbre :as timbre]
+            [jsoup.soup :as soup]
             [oc.lib.db.pool :as pool]
             [oc.lib.slack :as slack]
             [oc.lib.db.common :as db-common]
@@ -178,7 +179,7 @@
                   slack-channel (if bot-token (assoc channel :bot-token bot-token) channel)
                   channel-id (:channel-id slack-channel)
                   thread (:thread slack-channel)
-                  text (:body interaction)]
+                  text (.text (soup/parse (:body interaction)))]
               (if thread
                 (timbre/info "Echoing comment to Slack:" uuid "on thread" thread)
                 (timbre/info "Echoing comment to Slack:" uuid "as a new thread"))
@@ -224,7 +225,7 @@
                   channel-id (:channel-id slack-channel)
                   thread (:thread slack-channel)
                   author (-> message :author :name)
-                  text (str author " said: " (:body interaction))]
+                  text (str author " said: " (.text (soup/parse (:body interaction))))]
               (if thread
                 (timbre/info "Proxying comment to Slack:" uuid "on thread:" thread)
                 (timbre/info "Proxying comment to Slack:" uuid "as a new thread"))

--- a/src/oc/interaction/async/watcher.clj
+++ b/src/oc/interaction/async/watcher.clj
@@ -1,39 +1,11 @@
 (ns oc.interaction.async.watcher
   "
-  Track which WebSocket connections are 'watching' which items.
-
-  Use of this watcher is through core/async. A message is sent to the `watcher-chan` to
-  register interest, unregister interest and send something to all that have registered interest.
-
-  The sending to registered listeners is the resposibility of the user of this watcher and is
-  done by consuming the core.async `sender-chan`.
+  Small wrapper around oc.lib.watcher for building notification events.
   "
-  (:require [clojure.core.async :as async :refer [<!! >!!]]
-            [defun.core :refer (defun-)]
+  (:require [clojure.core.async :as async :refer [>!!]]
             [taoensso.timbre :as timbre]
+            [oc.lib.async.watcher :as watcher]
             [oc.interaction.representations.interaction :as interact-rep]))
-
-;; ----- core.async -----
-
-(defonce watcher-chan (async/chan 10000)) ; buffered channel
-(defonce sender-chan (async/chan 10000)) ; buffered channel
-
-(defonce watcher-go (atom nil))
-
-;; ----- Storage atom and functions -----
-
-(def watchers (atom {}))
-
-(defn add-watcher [watch-id client-id]
-  (let [item-watchers (or (get @watchers watch-id) #{})]
-    (swap! watchers assoc watch-id (conj item-watchers client-id))))
-
-(defn remove-watcher [watch-id client-id]
-  (let [item-watchers (or (get @watchers watch-id) #{})]
-    (swap! watchers assoc watch-id (disj item-watchers client-id))))
-
-(defn watchers-for [watch-id]
-  (vec (get @watchers watch-id)))
 
 ;; ----- Actions -----
 
@@ -47,76 +19,7 @@
   (let [initial-payload {:resource-uuid (:resource-uuid interaction)
                          :interaction (interact-rep/interaction-representation interaction :none)}
         payload (if reaction-count (assoc initial-payload :count reaction-count) initial-payload)]
-    (>!! watcher-chan {:send true
-                       :watch-id (:board-uuid interaction)
-                       :event event
-                       :payload payload}))))
-
-;; ----- Event handling -----
-
-(defn send-event
-  "Send outbound events to core.async channel"
-  [id event payload]
-  (timbre/debug "Send request to:" id)
-  (>!! sender-chan {:id id :event [event payload]}))
-
-(defun- handle-watch-message
-  "Handle 3 types of messages: watch, unwatch, send"
-  
-  ([message :guard :watch]
-  ;; Register interest by the specified client in the specified item by storing the client ID
-  (let [watch-id (:watch-id message)
-        client-id (:client-id message)]
-    (timbre/info "Watch request for:" watch-id "by:" client-id)
-    (add-watcher watch-id client-id)))
-
-  ([message :guard :unwatch]
-  ;; Unregister interest by the specified client in the specified item by removing the client ID
-  (let [watch-id (:watch-id message)
-        client-id (:client-id message)]
-    (timbre/info "Stop watch request for:" watch-id "by:" client-id)
-    (remove-watcher watch-id client-id)))
-
-  ([message :guard :send]
-  ;; For every client that's registered interest in the specified item, send them the specified event
-  (let [watch-id (:watch-id message)]
-    (timbre/info "Send request for:" watch-id)
-    (let [client-ids (watchers-for watch-id)]
-      (if (empty? client-ids)
-        (timbre/debug "No watchers for:" watch-id)
-        (timbre/debug "Send request to:" client-ids))
-      (doseq [client-id client-ids]
-        (send-event client-id (:event message) (:payload message))))))
-
-  ([message]
-  (timbre/warn "Unknown request in watch channel" message)))
-
-;; ----- Watcher event loop -----
-
-(defn watcher-loop []
-  (reset! watcher-go true)
-  (async/go (while @watcher-go
-    (timbre/debug "Watcher waiting...")
-    (let [message (<!! watcher-chan)]
-      (timbre/debug "Processing message on watcher channel...")
-      (if (:stop message)
-        (do (reset! watcher-go false) (timbre/info "Watcher stopped."))
-        (async/thread
-          (try
-            (handle-watch-message message)
-          (catch Exception e
-            (timbre/error e)))))))))
-
-;; ----- Component start/stop -----
-
-(defn start
-  "Start the core.async channel consumer for watching items."
-  []
-  (watcher-loop))
-
-(defn stop
-  "Stop the core.async channel consumer for watching items."
-  []
-  (when @watcher-go
-    (timbre/info "Stopping watcher...")
-    (>!! watcher-chan {:stop true})))
+    (>!! watcher/watcher-chan {:send true
+                               :watch-id (:board-uuid interaction)
+                               :event event
+                               :payload payload}))))

--- a/src/oc/interaction/components.clj
+++ b/src/oc/interaction/components.clj
@@ -3,9 +3,9 @@
             [taoensso.timbre :as timbre]
             [org.httpkit.server :as httpkit]
             [oc.lib.db.pool :as pool]
+            [oc.lib.async.watcher :as watcher]
             [oc.interaction.config :as c]
             [oc.interaction.api.websockets :as websockets-api]
-            [oc.interaction.async.watcher :as watcher]
             [oc.interaction.async.slack-mirror :as slack-mirror]))
 
 (defrecord HttpKit [options handler]


### PR DESCRIPTION
https://trello.com/c/QAr96JSp

This PR contains a small miscellany of things:

- Documentation updates
- Strip HTML from comments before mirroring them to Slack
-  Refactor to re-use watcher from oc.lib
- The following copy/formatting changes

Normalized the initial comment notification in the Slack channel for if it is either proxied:

http://take.ms/o6MVq

Or echo'd:

http://take.ms/POskl

Before these had different copy and treatments.

For subsequent comments, echo'd replies look just like Slack native: 

http://take.ms/BOC1n

But proxied comments come from the Bot, so we need to attribute the author. Before this was done w/ copy only in a way that made it hard to distinguish what the Bot was saying from what the user said. Using new formatting so it's now more clear with a block quote (similar to initial comment in the channel):

http://take.ms/0CKC8

To test:

- [x] Review code
- [x] Mainly thorough regression testing (this is already on staging, easiest to test there), comment from Slack and from Carrot (mirrored (write as user permission) and proxied (no write as user permission, but org does have the bot)). Check the copy of initial comments in channel and replies in thread, proxied and echo'd.
- [x] Write Carrot comments w/ newline white space. Should see stripped comment in Slack mirror. (Before you would have seen literal HTML tags in Slack)
- [x] Merge
- [x] Deploy
- [ ] Get a flu shot
