### PR TITLE
New slack comment thread scheme

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
     [clj-http "3.7.0"] ; HTTP client https://github.com/dakrone/clj-http
     [clj-soup/clojure-soup "0.1.3"] ; Clojure wrapper for jsoup HTML parser https://github.com/mfornos/clojure-soup
     
-    [open-company/lib "0.14.15"] ; Library for OC projects https://github.com/open-company/open-company-lib
+    [open-company/lib "0.16.0"] ; Library for OC projects https://github.com/open-company/open-company-lib
     ; In addition to common functions, brings in the following common dependencies used by this project:
     ; httpkit - Web server http://http-kit.org/
     ; core.async - Async programming and communication https://github.com/clojure/core.async
@@ -86,7 +86,7 @@
         :log-level "debug"
       }
       :plugins [
-        [lein-bikeshed "0.5.0"] ; Check for code smells https://github.com/dakrone/lein-bikeshed
+        [lein-bikeshed "0.5.1"] ; Check for code smells https://github.com/dakrone/lein-bikeshed
         [lein-checkall "0.1.1"] ; Runs bikeshed, kibit and eastwood https://github.com/itang/lein-checkall
         [lein-pprint "1.2.0"] ; pretty-print the lein project map https://github.com/technomancy/leiningen/tree/master/lein-pprint
         [lein-ancient "0.6.15"] ; Check for outdated dependencies https://github.com/xsc/lein-ancient


### PR DESCRIPTION
https://trello.com/c/oR339oGj

Supported by: https://github.com/open-company/open-company-lib/pull/25

Use a reply to an original comment message, rather than a reply link to get the comment thread going. This works around the need to create our own URL to the thread. Slack does it for us.

Also fixes author attribution when proxying comments with the bot.

To test:

- [x] Review code here and the oc.lib PR
- [x] You need a Slack org w/ the bot installed by 1 user, and also either an email user, or a user that denied the 2nd permissions
- [x] Create a new post, then add a first comment with user 1. You should see an echo'd comment (from user 1) and a Slack generated reply link. If you open the thread with the reply link, you should see user 1's comment as the 2nd message in the thread (aka reply 1).
- [x] Add another comment by user 1, does it go into the thread? Nice.
- [x] Add another comment by user 2, is it proxied into the thread by the bot? Brilliant. Is it properly attributed to user 2? Splendid.
- [x] Now create a 2nd new post.
- [x] Create a 1st comment in it with user 2. Is the first comment proxied by the bot and properly attributed to user 2? Alright!
- [x] Create a 2nd comment by user 2 and a 3rd comment by user 1. All into the thread and lookin' good? Damn straight skippy!
- [x] Merge this and the oc.lib PR

NB: This is already deployed on staging and on beta as I had to deploy it early to support the Slack review. No additional deploy needed unless code changes as part of the review.
