### PR TITLE
Change websockets API to support multiple board watches.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
     [clj-http "3.7.0"] ; HTTP client https://github.com/dakrone/clj-http
     [clj-soup/clojure-soup "0.1.3"] ; Clojure wrapper for jsoup HTML parser https://github.com/mfornos/clojure-soup
     
-    [open-company/lib "0.16.1"] ; Library for OC projects https://github.com/open-company/open-company-lib
+    [open-company/lib "0.16.3"] ; Library for OC projects https://github.com/open-company/open-company-lib
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - Web server http://http-kit.org/
     ;; core.async - Async programming and communication https://github.com/clojure/core.async

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
   ;; All profile dependencies
   :dependencies [
     [org.clojure/clojure "1.9.0"] ; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/core.cache "0.6.5"] ; Clojure in-memory caching https://github.com/clojure/core.cache
+    [org.clojure/core.cache "0.7.1"] ; Clojure in-memory caching https://github.com/clojure/core.cache
     [org.clojure/tools.cli "0.3.5"] ; Command-line parsing https://github.com/clojure/tools.cli
     [ring/ring-devel "1.6.3"] ; Web application library https://github.com/ring-clojure/ring
     [ring/ring-core "1.6.3"] ; Web application library https://github.com/ring-clojure/ring
@@ -22,7 +22,7 @@
     [jumblerg/ring.middleware.cors "1.0.1"] ; CORS library https://github.com/jumblerg/ring.middleware.cors
     [ring-logger-timbre "0.7.6" :exclusions [com.taoensso/encore]] ; Ring logging https://github.com/nberger/ring-logger-timbre
     [compojure "1.6.0"] ; Web routing https://github.com/weavejester/compojure
-    [clj-http "3.7.0"] ; HTTP client https://github.com/dakrone/clj-http
+    [clj-http "3.8.0"] ; HTTP client https://github.com/dakrone/clj-http
     [clj-soup/clojure-soup "0.1.3"] ; Clojure wrapper for jsoup HTML parser https://github.com/mfornos/clojure-soup
     
     [open-company/lib "0.16.3"] ; Library for OC projects https://github.com/open-company/open-company-lib
@@ -47,7 +47,7 @@
 
   ;; All profile plugins
   :plugins [
-    [lein-ring "0.12.3"] ; Common ring tasks https://github.com/weavejester/lein-ring
+    [lein-ring "0.12.4"] ; Common ring tasks https://github.com/weavejester/lein-ring
     [lein-environ "1.1.0"] ; Get environment settings from different sources https://github.com/weavejester/environ
   ]
 
@@ -62,7 +62,7 @@
         :open-company-auth-passphrase "this_is_a_qa_secret" ; JWT secret
       }
       :dependencies [
-        [midje "1.9.2-alpha2"] ; Example-based testing https://github.com/marick/Midje
+        [midje "1.9.2-alpha3"] ; Example-based testing https://github.com/marick/Midje
         [ring-mock "0.1.5"] ; Test Ring requests https://github.com/weavejester/ring-mock
       ]
       :plugins [


### PR DESCRIPTION
A client can now write to the websocket in order to watch a board. A client can now also unwatch a board or all boards.

To test use the web PR 
https://github.com/open-company/open-company-web/pull/395