### PR TITLE
Publish interaction CUD events to SNS for interested consumers.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,19 +13,19 @@
 
   ;; All profile dependencies
   :dependencies [
-    [org.clojure/clojure "1.9.0"] ; Lisp on the JVM http://clojure.org/documentation
+    [org.clojure/clojure "1.10.0-alpha6"] ; Lisp on the JVM http://clojure.org/documentation
     [org.clojure/core.cache "0.7.1"] ; Clojure in-memory caching https://github.com/clojure/core.cache
-    [org.clojure/tools.cli "0.3.5"] ; Command-line parsing https://github.com/clojure/tools.cli
-    [ring/ring-devel "1.6.3"] ; Web application library https://github.com/ring-clojure/ring
-    [ring/ring-core "1.6.3"] ; Web application library https://github.com/ring-clojure/ring
+    [org.clojure/tools.cli "0.3.7"] ; Command-line parsing https://github.com/clojure/tools.cli
+    [ring/ring-devel "1.7.0-RC1"] ; Web application library https://github.com/ring-clojure/ring
+    [ring/ring-core "1.7.0-RC1"] ; Web application library https://github.com/ring-clojure/ring
     [ring/ring-json "0.5.0-beta1"] ; JSON request/response https://github.com/ring-clojure/ring-json
     [jumblerg/ring.middleware.cors "1.0.1"] ; CORS library https://github.com/jumblerg/ring.middleware.cors
     [ring-logger-timbre "0.7.6" :exclusions [com.taoensso/encore]] ; Ring logging https://github.com/nberger/ring-logger-timbre
-    [compojure "1.6.0"] ; Web routing https://github.com/weavejester/compojure
-    [clj-http "3.8.0"] ; HTTP client https://github.com/dakrone/clj-http
+    [compojure "1.6.1"] ; Web routing https://github.com/weavejester/compojure
+    [clj-http "3.9.0"] ; HTTP client https://github.com/dakrone/clj-http
     [clj-soup/clojure-soup "0.1.3"] ; Clojure wrapper for jsoup HTML parser https://github.com/mfornos/clojure-soup
     
-    [open-company/lib "0.16.3"] ; Library for OC projects https://github.com/open-company/open-company-lib
+    [open-company/lib "0.16.10"] ; Library for OC projects https://github.com/open-company/open-company-lib
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - Web server http://http-kit.org/
     ;; core.async - Async programming and communication https://github.com/clojure/core.async
@@ -62,12 +62,12 @@
         :open-company-auth-passphrase "this_is_a_qa_secret" ; JWT secret
       }
       :dependencies [
-        [midje "1.9.2-alpha3"] ; Example-based testing https://github.com/marick/Midje
+        [midje "1.9.2"] ; Example-based testing https://github.com/marick/Midje
         [ring-mock "0.1.5"] ; Test Ring requests https://github.com/weavejester/ring-mock
       ]
       :plugins [
         [lein-midje "3.2.1"] ; Example-based testing https://github.com/marick/lein-midje
-        [jonase/eastwood "0.2.6-beta2"] ; Linter https://github.com/jonase/eastwood
+        [jonase/eastwood "0.2.8"] ; Linter https://github.com/jonase/eastwood
         [lein-kibit "0.1.6"] ; Static code search for non-idiomatic code https://github.com/jonase/kibit
       ]
     }
@@ -82,7 +82,8 @@
         :aws-access-key-id "CHANGE-ME"
         :aws-secret-access-key "CHANGE-ME"
         :aws-sqs-bot-queue "CHANGE-ME"
-        :aws-sqs-email-queue "CHANGE-ME"
+        :aws-sqs-slack-router-queue "CHANGE-ME"
+        :aws-sns-interaction-topic-arn "" ; SNS topic to publish notifications (optional)        
         :log-level "debug"
       }
       :plugins [

--- a/src/oc/interaction/app.clj
+++ b/src/oc/interaction/app.clj
@@ -53,8 +53,12 @@
     "Running on port: " port "\n"
     "Database: " c/db-name "\n"
     "Database pool: " c/db-pool-size "\n"
+    "AWS SQS Bot Queue: " c/aws-sqs-bot-queue "\n"
+    "AWS SQS Slack Queue: " c/aws-sqs-slack-router-queue "\n"
+    "AWS SNS notification topic ARN: " c/aws-sns-interaction-topic-arn "\n"
     "Hot-reload: " c/hot-reload "\n"
     "Trace: " c/liberator-trace "\n"
+    "Log level: " c/log-level "\n"
     "Sentry: " c/dsn "\n\n"
     (when c/intro? "Ready to serve...\n"))))
 

--- a/src/oc/interaction/async/notification.clj
+++ b/src/oc/interaction/async/notification.clj
@@ -1,0 +1,132 @@
+(ns oc.interaction.async.notification
+  "
+  Async publish of notification events to AWS SNS.
+  "
+  (:require [clojure.core.async :as async :refer (<! >!!)]
+            [taoensso.timbre :as timbre]
+            [cheshire.core :as json]
+            [amazonica.aws.sns :as sns]
+            [schema.core :as schema]
+            [oc.lib.schema :as lib-schema]
+            [oc.lib.time :as oc-time]
+            [oc.interaction.config :as config]
+            [oc.interaction.resources.interaction :as interact-res]))
+
+;; ----- core.async -----
+
+(defonce notification-chan (async/chan 10000)) ; buffered channel
+
+(defonce notification-go (atom true))
+
+;; ----- Utility functions -----
+
+(defn- resource-type [content]
+  (cond
+    (:reaction content) :reaction
+    :else :comment))
+
+;; ----- Data schema -----
+
+(defn- notification-type? [notification-type] (#{:add :update :delete} notification-type))
+
+(defn- resource-type? [resource-type] (#{:reaction :comment} resource-type))
+
+(def NotificationTrigger
+  "
+  A trigger for one of the various types of notifications that are published:
+
+  add - the interaction is newly created, this happens when a comment or reaction is added
+  update - the comment should be refreshed, this happens when a comment is updated
+  delete - the interaction is deleted, this happens when a comment or reaction is removed
+
+  The notification trigger contains the type of resource as `resource-type` and the content as `new` and/or
+  `old` in a key called `content`.
+
+  The user whose actions triggered the notification is included as `user`.
+
+  A timestamp for when the notice was created is included as `notification-at`.
+  "
+  {:notification-type (schema/pred notification-type?)
+   :resource-type (schema/pred resource-type?)
+   :uuid lib-schema/UniqueID
+   :org-uuid lib-schema/UniqueID
+   :board-uuid lib-schema/UniqueID
+   :content {
+    (schema/optional-key :new) (schema/conditional #(= (resource-type %) :comment) interact-res/Comment
+                                                   :else interact-res/Reaction)
+    (schema/optional-key :old) (schema/conditional #(= (resource-type %) :comment) interact-res/Comment
+                                                   :else interact-res/Reaction)}
+   :user lib-schema/User
+   :notification-at lib-schema/ISO8601})
+
+;; ----- Event handling -----
+
+(defn- handle-notification-message
+  [trigger]
+  (timbre/debug "Notification request of:" (:notification-type trigger)
+               "for:" (:uuid trigger) "to topic:" config/aws-sns-interaction-topic-arn)
+  (timbre/trace "Notification request:" trigger)
+  (schema/validate NotificationTrigger trigger)
+  (timbre/info "Sending request to topic:" config/aws-sns-interaction-topic-arn)
+  (sns/publish
+    {:access-key config/aws-access-key-id
+     :secret-key config/aws-secret-access-key}
+     :topic-arn config/aws-sns-interaction-topic-arn
+     :subject (str (name (:notification-type trigger))
+                   " on " (name (:resource-type trigger))
+                   ": " (-> trigger :current :uuid))
+     :message (json/generate-string trigger {:pretty true}))
+  (timbre/info "Request sent to topic:" config/aws-sns-interaction-topic-arn))
+
+;; ----- Event loop -----
+
+(defn- notification-loop []
+  (reset! notification-go true)
+  (timbre/info "Starting notification...")
+  (async/go (while @notification-go
+    (timbre/debug "Notification waiting...")
+    (let [message (<! notification-chan)]
+      (timbre/debug "Processing message on notification channel...")
+      (if (:stop message)
+        (do (reset! notification-go false) (timbre/info "Notification stopped."))
+        (async/thread
+          (try
+            (handle-notification-message message)
+          (catch Exception e
+            (timbre/error e)))))))))
+
+;; ----- Notification triggering -----
+
+(defn ->trigger [notification-type interaction content user]
+  {:notification-type notification-type
+   :resource-type (resource-type interaction)
+   :uuid (:uuid interaction)
+   :org-uuid (:org-uuid interaction)
+   :board-uuid  (:board-uuid interaction)
+   :content content
+   :user user
+   :notification-at (oc-time/current-timestamp)})
+
+(schema/defn ^:always-validate send-trigger! [trigger :- NotificationTrigger]
+  (if (clojure.string/blank? config/aws-sns-interaction-topic-arn)
+    (timbre/debug "Skipping a notification for:" (or (-> trigger :content :old :uuid)
+                                                     (-> trigger :content :new :uuid)))
+    (do
+      (timbre/debug "Triggering a notification for:" (or (-> trigger :content :old :uuid)
+                                                         (-> trigger :content :new :uuid)))
+      (>!! notification-chan trigger))))
+
+;; ----- Component start/stop -----
+
+(defn start
+  "Start the core.async event loop."
+  []
+  (when-not (clojure.string/blank? config/aws-sns-interaction-topic-arn) ; do we care about getting SNS notifications?
+    (notification-loop)))
+
+(defn stop
+  "Stop the the core.async event loop."
+  []
+  (when @notification-go
+    (timbre/info "Stopping notification...")
+    (>!! notification-chan {:stop true})))

--- a/src/oc/interaction/config.clj
+++ b/src/oc/interaction/config.clj
@@ -52,13 +52,15 @@
 (defonce ui-server-url (or (env :ui-server-url) "http://localhost:3559"))
 (defonce web-cdn-url (or (env :web-cdn-url) "https://do64qbk3yqbc.cloudfront.net"))
 
-;; ----- AWS SQS -----
+;; ----- AWS SQS / SNS -----
 
 (defonce aws-access-key-id (env :aws-access-key-id))
 (defonce aws-secret-access-key (env :aws-secret-access-key))
 
 (defonce aws-sqs-bot-queue (env :aws-sqs-bot-queue))
 (defonce aws-sqs-slack-router-queue (env :aws-sqs-slack-router-queue))
+
+(defonce aws-sns-interaction-topic-arn (env :aws-sns-interaction-topic-arn))
 
 ;; ----- JWT -----
 


### PR DESCRIPTION
https://trello.com/c/47Nk9JlP

Supported by infrastructure PR https://github.com/belucid/open-company-infrastructure/pull/72

To test:

- [x] Update your dev env to have your SNS ARN env. var. for your interaction topic (see the AWS SNS console, the topic is already setup for you, it looks like `oc-interaction-dev-<you>`)
- [x] Restart Interaction service
- [x] See new commandline output, including about the above configured SNS topic?
- [x] Did you see new component startup (async consumer)?
- [x] No startup errors?
- [x] CUD some comments in the Web UI
- [x] Did you see a log output about sending a notice for each comment CUD event to the SNS topic
- [x] No errors?
- [x] With this branch, C/D some reactions in the Web UI
- [x] Did you see a log output about sending a notice for each comment C/D event to the SNS topic
- [x] No errors?
- [x] Merge
- [ ] Deploy w/ the needed infrastructure branch