### PR TITLE
Watcher race condition

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
     [clj-soup/clojure-soup "0.1.3"] ; Clojure wrapper for jsoup HTML parser https://github.com/mfornos/clojure-soup
     ;; String library
     
-    [open-company/lib "0.16.22alpha"] ; Library for OC projects https://github.com/open-company/open-company-lib
+    [open-company/lib "0.16.22"] ; Library for OC projects https://github.com/open-company/open-company-lib
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - Web server http://http-kit.org/
     ;; core.async - Async programming and communication https://github.com/clojure/core.async

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
     [clj-soup/clojure-soup "0.1.3"] ; Clojure wrapper for jsoup HTML parser https://github.com/mfornos/clojure-soup
     ;; String library
     
-    [open-company/lib "0.16.19"] ; Library for OC projects https://github.com/open-company/open-company-lib
+    [open-company/lib "0.16.22alpha"] ; Library for OC projects https://github.com/open-company/open-company-lib
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; httpkit - Web server http://http-kit.org/
     ;; core.async - Async programming and communication https://github.com/clojure/core.async


### PR DESCRIPTION
Review with https://github.com/open-company/open-company-lib/pull/41

To test:
- add logs of the `watchers` at the end of `oc.lib.async.watcher/add-watcher` and `oc.lib.async.watcher/remove-watcher`
- now with the client open AP
- navigate to a single section
- navigate to another single section
- navigate to MS
- close
- now get the logs and make sure that in every print the watcher always have the same number of client-ids as keys and as value of each container (if a client-id is watching a container it needs to be in the list for that container but also the container needs to be in its list, so just check the number is the same).

NB: with the race condition i found the problem was that the client-id was removed as key from `watchers` var but not from within the container list of client-ids. Ping me if you need more info on how to check this