### PR TITLE
Comment 😀reactions

### DIFF
--- a/src/oc/interaction/api/comments.clj
+++ b/src/oc/interaction/api/comments.clj
@@ -88,7 +88,7 @@
 (defresource comment-item [conn org-uuid board-uuid resource-uuid comment-uuid]
   (api-common/open-company-id-token-resource config/passphrase) ; verify validity and presence of required JWToken
 
-  :allowed-methods [:options :post :patch :delete]
+  :allowed-methods [:options :patch :delete]
 
   ;; Media type client accepts
   :available-media-types [interact-rep/comment-media-type]
@@ -200,12 +200,6 @@
         [org-uuid board-uuid resource-uuid comment-uuid]
         (pool/with-pool [conn db-pool] (comment-item conn org-uuid board-uuid resource-uuid comment-uuid)))
       (ANY "/orgs/:org-uuid/boards/:board-uuid/resources/:resource-uuid/comments/:comment-uuid/"
-        [org-uuid board-uuid resource-uuid comment-uuid]
-        (pool/with-pool [conn db-pool] (comment-item conn org-uuid board-uuid resource-uuid comment-uuid)))
-      (ANY "/orgs/:org-uuid/boards/:board-uuid/resources/:resource-uuid/comments/:comment-uuid/react"
-        [org-uuid board-uuid resource-uuid comment-uuid]
-        (pool/with-pool [conn db-pool] (comment-item conn org-uuid board-uuid resource-uuid comment-uuid)))
-      (ANY "/orgs/:org-uuid/boards/:board-uuid/resources/:resource-uuid/comments/:comment-uuid/react/"
         [org-uuid board-uuid resource-uuid comment-uuid]
         (pool/with-pool [conn db-pool] (comment-item conn org-uuid board-uuid resource-uuid comment-uuid))))))
 

--- a/src/oc/interaction/api/comments.clj
+++ b/src/oc/interaction/api/comments.clj
@@ -88,7 +88,7 @@
 (defresource comment-item [conn org-uuid board-uuid resource-uuid comment-uuid]
   (api-common/open-company-id-token-resource config/passphrase) ; verify validity and presence of required JWToken
 
-  :allowed-methods [:options :patch :delete]
+  :allowed-methods [:options :post :patch :delete]
 
   ;; Media type client accepts
   :available-media-types [interact-rep/comment-media-type]
@@ -201,4 +201,11 @@
         (pool/with-pool [conn db-pool] (comment-item conn org-uuid board-uuid resource-uuid comment-uuid)))
       (ANY "/orgs/:org-uuid/boards/:board-uuid/resources/:resource-uuid/comments/:comment-uuid/"
         [org-uuid board-uuid resource-uuid comment-uuid]
+        (pool/with-pool [conn db-pool] (comment-item conn org-uuid board-uuid resource-uuid comment-uuid)))
+      (ANY "/orgs/:org-uuid/boards/:board-uuid/resources/:resource-uuid/comments/:comment-uuid/react"
+        [org-uuid board-uuid resource-uuid comment-uuid]
+        (pool/with-pool [conn db-pool] (comment-item conn org-uuid board-uuid resource-uuid comment-uuid)))
+      (ANY "/orgs/:org-uuid/boards/:board-uuid/resources/:resource-uuid/comments/:comment-uuid/react/"
+        [org-uuid board-uuid resource-uuid comment-uuid]
         (pool/with-pool [conn db-pool] (comment-item conn org-uuid board-uuid resource-uuid comment-uuid))))))
+

--- a/src/oc/interaction/api/reactions.clj
+++ b/src/oc/interaction/api/reactions.clj
@@ -61,7 +61,7 @@
 (defresource reaction [conn org-uuid board-uuid resource-uuid reaction-unicode]
   (api-common/open-company-id-token-resource config/passphrase) ; verify validity and presence of required JWToken
 
-  :allowed-methods [:options :put :delete]
+  :allowed-methods [:options :post :put :delete]
 
   ;; Media type client accepts
   :available-media-types [interact-rep/reaction-media-type]
@@ -90,6 +90,9 @@
                                           reaction-unicode
                                           (-> ctx :existing-reactions count inc))))
   :delete! (fn [ctx] (delete-reaction conn ctx))
+
+  :post! (fn [ctx]
+           (create-reaction conn ctx org-uuid board-uuid resource-uuid (-> ctx :data)))
 
   ;; Responses
   :respond-with-entity? true
@@ -182,4 +185,11 @@
         (pool/with-pool [conn db-pool] (reaction conn org-uuid board-uuid resource-uuid reaction-unicode)))
       (ANY "/orgs/:org-uuid/boards/:board-uuid/resources/:resource-uuid/reactions/:reaction-unicode/on/"
         [org-uuid board-uuid resource-uuid reaction-unicode]
-        (pool/with-pool [conn db-pool] (reaction conn org-uuid board-uuid resource-uuid reaction-unicode))))))
+        (pool/with-pool [conn db-pool] (reaction conn org-uuid board-uuid resource-uuid reaction-unicode)))
+      ;; Add new arbitrary reaction
+      (ANY "/orgs/:org-uuid/boards/:board-uuid/resources/:resource-uuid/react"
+        [org-uuid board-uuid resource-uuid]
+        (pool/with-pool [conn db-pool] (reaction conn org-uuid board-uuid resource-uuid nil)))
+      (ANY "/orgs/:org-uuid/boards/:board-uuid/resources/:resource-uuid/react/"
+        [org-uuid board-uuid resource-uuid]
+        (pool/with-pool [conn db-pool] (reaction conn org-uuid board-uuid resource-uuid nil))))))

--- a/src/oc/interaction/config.clj
+++ b/src/oc/interaction/config.clj
@@ -70,7 +70,3 @@
 ;; ----- Slack -----
 
 (defonce slack-verification-token (env :open-company-slack-verification-token))
-
-;; ----- Interaction service -----
-
-(defonce default-comment-reactions ["👍"])

--- a/src/oc/interaction/representations/interaction.clj
+++ b/src/oc/interaction/representations/interaction.clj
@@ -49,7 +49,7 @@
 (defun- reaction-link 
   ([reaction-url] (hateoas/link-map "react" hateoas/POST
                     reaction-url
-                    {:content-type "text/plain"
+                    {:content-type reaction-media-type
                      :accept reaction-media-type}))
   ([reaction-url true] (hateoas/link-map "react" hateoas/DELETE reaction-url {}))
   ([reaction-url false] (hateoas/link-map "react" hateoas/PUT reaction-url {:accept reaction-media-type})))
@@ -91,9 +91,7 @@
 (defn- comment-reactions
   [interaction user collection-url]
   (if (:body interaction)
-    (let [default-reactions (apply hash-map (interleave config/default-comment-reactions (repeat [])))
-          grouped-reactions (merge default-reactions
-                                   (group-by :reaction (:reactions interaction))) ; reactions grouped by unicode character
+    (let [grouped-reactions (group-by :reaction (:reactions interaction)) ; reactions grouped by unicode character
           counted-reactions-map (map-kv count grouped-reactions) ; how many for each character?
           counted-reactions (map #(vec [% (get counted-reactions-map %)]) (keys counted-reactions-map))
           reaction-authors (map #(:user-id (:author %)) (:reactions interaction))

--- a/src/oc/interaction/representations/interaction.clj
+++ b/src/oc/interaction/representations/interaction.clj
@@ -35,7 +35,7 @@
   (url (:org-uuid interaction) (:board-uuid interaction) (:resource-uuid interaction) (:reaction interaction)))
 
   ([interaction :guard :comment-react]
-    (str (url (dissoc interaction :comment-react)) "/react"))
+    (str (url (:org-uuid interaction) (:board-uuid interaction) (:uuid interaction)) "/react"))
 
   ([interaction]
   (str (url (:org-uuid interaction) (:board-uuid interaction) (:resource-uuid interaction))


### PR DESCRIPTION
Main PR: https://github.com/open-company/open-company-web/pull/879

To test backward compatibility (with Carrot 1.0 web client, `mainline` branch):
- leave some comments
- react to some posts using the picker
- react to some posts using reactions used by other users (not the picker)
- remove your reactions to some posts
- edit a comment
- delete a comment
- make sure you don't see any agree with this comment button: the button was already removed from the UI though, this PR also removes the links to add/remove it