### PR TITLE
Include family emojis

### DIFF
--- a/src/oc/interaction/api/reactions.clj
+++ b/src/oc/interaction/api/reactions.clj
@@ -20,8 +20,8 @@
 (defn- valid-reaction-unicode? [reaction-unicode]
   (and (string? reaction-unicode)
        ;; TODO need to verify it's just 1 Unicode char, counting code points doesn't
-       ;; work because something like 🇫🇰 is 2, for now just verify it's 4 or less code points
-       (<= (.codePointCount reaction-unicode 0 (count reaction-unicode)) 11)))
+       ;; work because something like 👩‍👩‍👦‍👦 is 11, for now just verify it's 16 or less code points
+       (<= (.codePointCount reaction-unicode 0 (count reaction-unicode)) 16)))
 
 ;; ----- Actions -----
 

--- a/src/oc/interaction/api/reactions.clj
+++ b/src/oc/interaction/api/reactions.clj
@@ -21,7 +21,7 @@
   (and (string? reaction-unicode)
        ;; TODO need to verify it's just 1 Unicode char, counting code points doesn't
        ;; work because something like 🇫🇰 is 2, for now just verify it's 4 or less code points
-       (<= (.codePointCount reaction-unicode 0 (count reaction-unicode)) 4)))
+       (<= (.codePointCount reaction-unicode 0 (count reaction-unicode)) 11)))
 
 ;; ----- Actions -----
 


### PR DESCRIPTION
Emojis like this: 👩‍👩‍👦‍👦 can be composed by up to 4 composed emojis and they can have up to 11 codepoints.

```
user=> (count 👩👩👦👦)
Syntax error compiling at (REPL:1:1).
Unable to resolve symbol: 👩‍👩‍👦‍👦 in this context

user=> (count "👩👩👦👦")
11
```

So i extended the count check.

To test:
- add a family reaction to a post
- [x] no 422? Good
- [x] can you see the reaction under the post? Good